### PR TITLE
Allow storage path to be specified/overidden

### DIFF
--- a/pack/commands.cfg
+++ b/pack/commands.cfg
@@ -12,7 +12,7 @@ define command {
 
 define command {
        command_name     check_linux_disks
-       command_line	$PLUGINSDIR$/check_snmp_storage.pl -H $HOSTADDRESS$ -C $_HOSTSNMPCOMMUNITY$ -m "/" -f -w $_HOSTSTORAGE_WARN$ -c $_HOSTSTORAGE_CRIT$ -S0,1 -o $_HOSTSNMP_MSG_MAX_SIZE$
+       command_line	$PLUGINSDIR$/check_snmp_storage.pl -H $HOSTADDRESS$ -C $_HOSTSNMPCOMMUNITY$ -m $_HOSTSTORAGE_PATH$ -f -w $_HOSTSTORAGE_WARN$ -c $_HOSTSTORAGE_CRIT$ -S0,1 -o $_HOSTSNMP_MSG_MAX_SIZE$
 }
 
 define command {

--- a/pack/templates.cfg
+++ b/pack/templates.cfg
@@ -25,6 +25,7 @@ define host{
    _NET_CRIT                    0,0,0,0,0,0
 
    _CHKLOG_CONF                 $PLUGINSDIR$/logFiles_linux.conf
+   _STORAGE_PATH		/
 }
 
 


### PR DESCRIPTION
Allow storage path to be overriden while maintaining the default for backwards compatibility.
