### PR TITLE
Add "-OU" option to snmpget to remove "kB" unit

### DIFF
--- a/libexec/check_snmp_mem.pl
+++ b/libexec/check_snmp_mem.pl
@@ -59,7 +59,8 @@ my $STR = join(" ", @ARGV);
 sub do_snmp {
 	my ($OID) = @_;
 
-	my $cmd = $snmpget . " " . $STR . " " . $OID;
+	# Option "-OU" to remove the "kB" unit.
+	my $cmd = $snmpget . " -OU " . $STR . " " . $OID;
 
 	chomp(my $out = `$cmd 2> /dev/null`);
 
@@ -102,7 +103,7 @@ if ($swap) {
 
 	$realPercent = (($swapTotal - $swapFree) / $swapTotal) * 100;
 
-	$status_str = "Free => $swapFree Kb, Total => $swapTotal Kb|swap_free=$swapFree swap_total=$swapTotal";
+	$status_str = "Free => $swapFree kB, Total => $swapTotal kB|swap_free=$swapFree swap_total=$swapTotal";
 
 } else {
 
@@ -128,7 +129,7 @@ if ($swap) {
 
 	$realPercent = (($memRealUsed - $memRealBuffers - $memRealCached )/ $memRealTotal) * 100;
 
-	$status_str = "Free => $memRealFree Kb, Total => $memRealTotal Kb, Cached => $memRealCached Kb, Buffered => $memRealBuffers Kb|ram_free=$memRealFree ram_total=$memRealTotal ram_cached=$memRealCached ram_buffered=$memRealBuffers";
+	$status_str = "Free => $memRealFree kB, Total => $memRealTotal kB, Cached => $memRealCached kB, Buffered => $memRealBuffers kB|ram_free=$memRealFree ram_total=$memRealTotal ram_cached=$memRealCached ram_buffered=$memRealBuffers";
 
 }
 


### PR DESCRIPTION
# Fix performance data

On my setup, by default, snmpget return this:

```bash
snmpget -v2c -c public test.example.com 1.3.6.1.4.1.2021.4.6.0
UCD-SNMP-MIB::memAvailReal.0 = INTEGER: 719252 kB
```

This break the performance data. Adding "-OU" resolve this problem:

```bash
snmpget -v2c -c public test.example.com 1.3.6.1.4.1.2021.4.6.0 -OU
UCD-SNMP-MIB::memAvailReal.0 = INTEGER: 719252
```

# Fix unit case

I replaced the "Kb" (Kilo Bit; 1 kb = 1024 bits) by "kB" (Kilo Byte; 1 kB = 8 kb), as it's what is actually returned by SNMPd.

# Note

I wonder if we should not output performance data in Bytes, instead of Kilo Bytes.