### PR TITLE
Prevent Argument "v6.0.1" isn't numeric

### DIFF
--- a/libexec/check_snmp_load.pl
+++ b/libexec/check_snmp_load.pl
@@ -350,7 +350,7 @@ if ($o_check_type eq "netsl") {
 
 verb("Checking linux load");
 # Get load table
-my $resultat = (Net::SNMP->VERSION < 4) ?
+my $resultat = (Net::SNMP->VERSION lt 4) ?
 		  $session->get_table($linload_table)
 		: $session->get_table(Baseoid => $linload_table);
 
@@ -414,7 +414,7 @@ exit $exit_val;
 
 if ($o_check_type eq "cisco") {
 my @oidlists = ($cisco_cpu_5m, $cisco_cpu_1m, $cisco_cpu_5s);
-my $resultat = (Net::SNMP->VERSION < 4) ?
+my $resultat = (Net::SNMP->VERSION lt 4) ?
 	  $session->get_request(@oidlists)
 	: $session->get_request(-varbindlist => \@oidlists);
 
@@ -469,7 +469,7 @@ exit $exit_val;
 
 if ($o_check_type eq "cata") {
 my @oidlists = ($ciscocata_cpu_5m, $ciscocata_cpu_1m, $ciscocata_cpu_5s);
-my $resultat = (Net::SNMP->VERSION < 4) ?
+my $resultat = (Net::SNMP->VERSION lt 4) ?
 	  $session->get_request(@oidlists)
 	: $session->get_request(-varbindlist => \@oidlists);
 
@@ -524,7 +524,7 @@ exit $exit_val;
 
 if ($o_check_type eq "nsc") {
 my @oidlists = ($nsc_cpu_5m, $nsc_cpu_1m, $nsc_cpu_5s);
-my $resultat = (Net::SNMP->VERSION < 4) ?
+my $resultat = (Net::SNMP->VERSION lt 4) ?
 	  $session->get_request(@oidlists)
 	: $session->get_request(-varbindlist => \@oidlists);
 
@@ -581,7 +581,7 @@ if ( $o_check_type =~ /netsc|as400|bc|nokia|^hp$|lp|fg/ ) {
 # Get load table
 my @oidlist = $cpu_oid{$o_check_type};
 verb("Checking OID : @oidlist");
-my $resultat = (Net::SNMP->VERSION < 4) ?
+my $resultat = (Net::SNMP->VERSION lt 4) ?
 	  $session->get_request(@oidlist)
 	: $session->get_request(-varbindlist => \@oidlist);
 if (!defined($resultat)) {
@@ -629,7 +629,7 @@ if ($o_check_type eq "hpux") {
 verb("Checking hpux load");
 
 my @oidlists = ($hpux_load_1_min, $hpux_load_5_min, $hpux_load_15_min);
-my $resultat = (Net::SNMP->VERSION < 4) ?
+my $resultat = (Net::SNMP->VERSION lt 4) ?
 	  $session->get_request(@oidlists)
 	: $session->get_request(-varbindlist => \@oidlists);
 
@@ -682,7 +682,7 @@ exit $exit_val;
 
 ########## Standard cpu usage check ############
 # Get desctiption table
-my $resultat =  (Net::SNMP->VERSION < 4) ?
+my $resultat =  (Net::SNMP->VERSION lt 4) ?
 	  $session->get_table($base_proc)
 	: $session->get_table(Baseoid => $base_proc);
 


### PR DESCRIPTION
I have encountered an error with version similar to  #12, this is the link: https://github.com/shinken-monitoring/pack-linux-snmp/commit/13a65fdb4efaa8362775223f2ce382f49ca0c850

The difference is just the file where to change the comparison of SNMP version.
Tested in our production environment, RRD graphs are also been drawn correcty.

The previous output was:
<pre>
./check_snmp_load.pl -H 10.20.30.40 -C public -f -w 80 -c 90
Argument "v6.0.1" isn't numeric in numeric lt (<) at ./check_snmp_load.pl line 685.
1 CPU, load 50.0% < 80% : OK | cpu_prct_used=50%;80;90
</pre>

And the current:
<pre>
./check_snmp_load.pl -H 10.20.30.40 -C public -f -w 80 -c 90         
1 CPU, load 43.0% < 80% : OK | cpu_prct_used=43%;80;90
</pre>
