### PR TITLE
Isolate returned value from units when asking for Memory oids

### DIFF
--- a/libexec/check_snmp_mem.pl
+++ b/libexec/check_snmp_mem.pl
@@ -69,12 +69,14 @@ sub do_snmp {
 	}
 
 	my $type;
+	my $units;
 
 	my ($jnk, $x) = split / = /, $out, 2;
 
-	if ($x =~ /([a-zA-Z0-9]+): (.*)$/) {
+	if ($x =~ /([a-zA-Z0-9]+): ([0-9]+)(.*)$/) {
 		$type = $1;
 		$x = $2;
+		$units = $3;
 	}
 
 	return $x;


### PR DESCRIPTION
I have encountered perl type conversion warnings when trying to compare or operate with the memory values returned from the script.
<pre>
perl check_snmp_mem.pl -w 80 -c 95 -- -v 2c -c public 10.20.30.40
Argument "1032648 kB" isn't numeric in numeric eq (==) at check_snmp_mem.pl line 122.
el valor es:1032648 kBArgument "110904 kB" isn't numeric in subtraction (-) at check_snmp_mem.pl line 131.
Argument "4392 kB" isn't numeric in subtraction (-) at check_snmp_mem.pl line 133.
Argument "184128 kB" isn't numeric in subtraction (-) at check_snmp_mem.pl line 133.
MEMORY OK: 71.00 % used; Free => 110904 kB Kb, Total => 1032648 kB Kb, Cached => 184128 kB Kb, Buffered => 4392 kB Kb|ram_free=110904 kB ram_total=1032648 kB ram_cached=184128 kB ram_buffered=4392 kB
</pre>

The problem is targeted in the units "kB" returned from the host, it must operate only with the numeric values instead of the full string.

It was finishing the arithmetic operations but the RRD generated was not correct, cause all the warning output. I have test it omitting the warnings, but i think the correct way is capturing the real numbers.
<pre>
no warnings 'numeric';
</pre>