### PR TITLE
Allow to set the -T option of check_snmp_load.pl

### DIFF
--- a/pack/commands.cfg
+++ b/pack/commands.cfg
@@ -7,7 +7,7 @@
 #
 define command {
     command_name  check_linux_load
-    command_line  $PLUGINSDIR$/check_snmp_load.pl -H $HOSTADDRESS$ -C $_HOSTSNMPCOMMUNITY$ -f -w $_HOSTLOAD_WARN$ -c $_HOSTLOAD_CRIT$ -T netsl -o $_HOSTSNMP_MSG_MAX_SIZE$
+    command_line  $PLUGINSDIR$/check_snmp_load.pl -H $HOSTADDRESS$ -C $_HOSTSNMPCOMMUNITY$ -f -T $_HOSTCHECK_TYPE_L$ -w $_HOSTLOAD_WARN$ -c $_HOSTLOAD_CRIT$ -o $_HOSTSNMP_MSG_MAX_SIZE$
 }
 
 define command {
@@ -17,7 +17,7 @@ define command {
 
 define command {
     command_name  check_linux_cpu
-    command_line  $PLUGINSDIR$/check_snmp_load.pl -H $HOSTADDRESS$ -C $_HOSTSNMPCOMMUNITY$ -f -w $_HOSTCPU_WARN$ -c $_HOSTCPU_CRIT$ -o $_HOSTSNMP_MSG_MAX_SIZE$
+    command_line  $PLUGINSDIR$/check_snmp_load.pl -H $HOSTADDRESS$ -C $_HOSTSNMPCOMMUNITY$ -f -T $_HOSTCHECK_TYPE_C$ -w $_HOSTCPU_WARN$ -c $_HOSTCPU_CRIT$ -o $_HOSTSNMP_MSG_MAX_SIZE$
 }
 
 # Added -g flag since all linux system used are 64bits.

--- a/pack/templates.cfg
+++ b/pack/templates.cfg
@@ -11,6 +11,8 @@ define host {
     _SNMPCOMMUNITY      $SNMPCOMMUNITYREAD$
     _SNMP_MSG_MAX_SIZE  65535
 
+    _CHECK_TYPE_C       stand
+    _CHECK_TYPE_L       netsl
     _LOAD_WARN          2,2,2
     _LOAD_CRIT          3,3,3
     _STORAGE_WARN       98


### PR DESCRIPTION
This patch allows to get ride of the "Can't find CPU usage information : UNKNOWN" error, which happen with old version of snmp, by setting another check type.
The parameter was harcoded for the load check, probably to avoid an error with teh default value.
It's yet more generic.
