### PR TITLE
Update check_netint.pl

### DIFF
--- a/libexec/check_netint.pl
+++ b/libexec/check_netint.pl
@@ -618,7 +618,7 @@ my $file_history=200;   # number of lines of data to keep in file
 # SNMP OID Datas
 my $inter_table= '.1.3.6.1.2.1.2.2.1';
 my $index_table = '1.3.6.1.2.1.2.2.1.1';
-my $descr_table = '1.3.6.1.2.1.2.2.1.2';
+my $descr_table = '1.3.6.1.2.1.31.1.1.1.1';
 my $oper_table = '1.3.6.1.2.1.2.2.1.8.';
 my $admin_table = '1.3.6.1.2.1.2.2.1.7.';
 my $speed_table = '1.3.6.1.2.1.2.2.1.5.';


### PR DESCRIPTION
Hello,

I recently switched some of my debian systems to jessie, and check_netint.pl started not to work because all interface names where the same, with manufacturer names instead of unique interface names.

I found info here : http://serverfault.com/questions/713660/snmp-getting-the-short-interface-name-instead-of-long-ifdescr-again

It seems that the relevant info is in OID 1.3.6.1.2.1.31.1.1.1.1 instead of 1.3.6.1.2.1.2.2.1.2

Apparently there has been some confusion between ifName and ifDescr in the past : things worked before because ifDescr did, in fact, contain the name. Now debian 8 exhibits the correct behavior (see http://cric.grenoble.cnrs.fr/Administrateurs/Outils/MIBS/?oid=1.3.6.1.2.1.31.1.1.1.1 vs http://cric.grenoble.cnrs.fr/Administrateurs/Outils/MIBS/?oid=1.3.6.1.2.1.2.2.1.2)

This PR proposes to make the switch in order to recover the expected behavior. I tested it on my system.