### PR TITLE
command check_linux_network_usage : Add option to define OID of descr…

### DIFF
--- a/pack/commands.cfg
+++ b/pack/commands.cfg
@@ -23,7 +23,7 @@ define command {
 # Added -g flag since all linux system used are 64bits.
 define command {
     command_name  check_linux_network_usage
-    command_line  $PLUGINSDIR$/check_netint.pl -H $HOSTADDRESS$ -C $_HOSTSNMPCOMMUNITY$ -n "$_HOSTNET_IFACES$" -g -2c -f -e -w $_HOSTNET_WARN$ -c $_HOSTNET_CRIT$ -q -k -y -M -B -m -P "$SERVICEPERFDATA$" -T "$LASTSERVICECHECK$"  -o $_HOSTSNMP_MSG_MAX_SIZE$
+    command_line  $PLUGINSDIR$/check_netint.pl -H $HOSTADDRESS$ -C $_HOSTSNMPCOMMUNITY$ -n "$_HOSTNET_IFACES$" -g -2c -f -e -w $_HOSTNET_WARN$ -c $_HOSTNET_CRIT$ -q -k -y -M -B -m -P "$SERVICEPERFDATA$" -T "$LASTSERVICECHECK$"  -o $_HOSTSNMP_MSG_MAX_SIZE$ -N $_HOSTOID_IF_TABLE_DESCR$
 }
 
 define command {

--- a/pack/templates.cfg
+++ b/pack/templates.cfg
@@ -11,6 +11,11 @@ define host {
     _SNMPCOMMUNITY      $SNMPCOMMUNITYREAD$
     _SNMP_MSG_MAX_SIZE  65535
 
+    # The historical IF table description OID 1.3.6.1.2.1.2.2.1.2
+    # must be replace by IF-MIB::ifName (1.3.6.1.2.1.31.1.1.1.1) 
+    # for host in ubuntu 16.04 for example
+    _OID_IF_TABLE_DESCR 1.3.6.1.2.1.2.2.1.2
+
     _CHECK_TYPE_C       stand
     _CHECK_TYPE_L       netsl
     _LOAD_WARN          2,2,2


### PR DESCRIPTION
With ubuntu 16.04 IF-MIB::ifDescr only contains constructor name, the interface name is in IF-MIB::ifName.

This patch aims to be able to define the OID in host definition instead of modifying check_netint.pl